### PR TITLE
Add SC Members to Active Team

### DIFF
--- a/docs/team/contributors-jupyter-server.yaml
+++ b/docs/team/contributors-jupyter-server.yaml
@@ -1,5 +1,12 @@
 # Active Team members
 # Use ALPHABETICAL (BY LAST NAME) ORDER please :-)
+
+- name: Damian Avila
+  handle: "@damianavila"
+  affiliation: UMSI and 2i2c
+  team: active
+  last-check-in: 2022-01
+
 - name: Kevin Bates
   handle: "@kevin-bates"
   affiliation: IBM
@@ -33,6 +40,18 @@
 - name: Vidar Fauske
   handle: "@vidartf"
   affiliation: J.P. Morgan Chase
+  team: active
+  last-check-in: 2022-01
+
+- name: Brian Granger
+  handle: "@ellisonbg"
+  affiliation: Amazon Web Services
+  team: active
+  last-check-in: 2022-01
+
+- name: Paul Ivanov
+  handle: "@ivanov"
+  affiliation: Noteable
   team: active
   last-check-in: 2022-01
 


### PR DESCRIPTION
It was mentioned in today's meeting that there were a number of current Steering Council members who elected to join the initial Jupyter Server Team. Adding them to the team here. 

@ivanov @ellisonbg and @damianavila, please confirm that your info here is correct (particularly your affiliations). Thanks!