### PR TITLE
Add Carol to Jupyter Server Council

### DIFF
--- a/docs/team/contributors-jupyter-server.yaml
+++ b/docs/team/contributors-jupyter-server.yaml
@@ -79,6 +79,12 @@
   team: active
   last-check-in: 2022-01
 
+- name: Carol Willing
+  handle: "@willingc"
+  affiliation: Noteable
+  team: active
+  last-check-in: 2022-03
+
 - name: Jessica Xu
   handle: "@jess-x"
   affiliation: Quansight


### PR DESCRIPTION
@willingc would like to join the Jupyter Server Council as part of the [bootstrapping process](https://jupyter.org/governance/bootstrapping_decision_making.html).