### PR TITLE
Add Rahul to active team members

### DIFF
--- a/docs/team/contributors-jupyter-server.yaml
+++ b/docs/team/contributors-jupyter-server.yaml
@@ -43,6 +43,12 @@
   team: active
   last-check-in: 2022-01
 
+- name: Rahul Goyal
+  handle: "@rahul26goyal"
+  affiliation: Amazon Web Services
+  team: active
+  last-check-in: 2022-04
+
 - name: Brian Granger
   handle: "@ellisonbg"
   affiliation: Amazon Web Services


### PR DESCRIPTION
It's my privilege to welcome Rahul Goyal as the newest member of the Jupyter Server team!  Rahul has been actively participating in the Jupyter Server team meetings while contributing to Enterprise Gateway since late last year and will be a significant asset to the Jupyter ecosystem.  

**Welcome to the team Rahul!** :tada: