### PR TITLE
Move kevin-bates to inactive

### DIFF
--- a/docs/team/contributors-jupyter-server.yaml
+++ b/docs/team/contributors-jupyter-server.yaml
@@ -7,12 +7,6 @@
   team: active
   last-check-in: 2024-01
 
-- name: Kevin Bates
-  handle: "@kevin-bates"
-  affiliation: IBM
-  team: active
-  last-check-in: 2024-01
-
 - name: David Brochart
   handle: "@davidbrochart"
   affiliation: Quantstack
@@ -86,6 +80,12 @@
   last-check-in: 2024-01
 
 # Inactive team members at the end, also alphabetical
+- name: Kevin Bates
+  handle: "@kevin-bates"
+  affiliation: Veritone
+  team: inactive
+  last-check-in: 2024-04
+
 - name: Jeremy Tuloup
   handle: "@jtpio"
   affiliation: Quantstack


### PR DESCRIPTION
I'm sorry, but I think it best I be moved to _inactive_ since I'm unable to participate at an "active" level. I will try to monitor the community's activity in the meantime, and intend to become active again down the road.

Take care,
Kevin.