### PR TITLE
Welcome Vidar as next SSC Rep! 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 _build
-docs/team/active.txt
-docs/team/inactive.txt
+docs/team/*.txt
 .ipynb_checkpoints
 .vscode

--- a/docs/scripts/gen_contributors.py
+++ b/docs/scripts/gen_contributors.py
@@ -67,3 +67,21 @@ inactive_people = people[people.team == "inactive"]
 table = _generate_contributors(inactive_people)
 with open(source_dir / "inactive.txt", "w") as ff:
     ff.write(table)
+
+# Find past and current SSC representatives
+ssc_reps = people[people.ssc.notna()]
+for index, rep in ssc_reps.iterrows():
+    # Fetch the latest term
+    latest_term = rep.ssc[-1]
+    # Split date and check if there is an end date.
+    is_current = latest_term.split("-")[-1] == ""
+    if is_current:
+        break
+
+table = _generate_contributors(rep.to_frame().T)
+with open(source_dir / "ssc-current.txt", "w") as ff:
+    ff.write(table)
+
+table = _generate_contributors(ssc_reps.drop(index))
+with open(source_dir / "ssc-past.txt", "w") as ff:
+    ff.write(table)

--- a/docs/team.md
+++ b/docs/team.md
@@ -26,4 +26,20 @@ Inactive team members are (temporarily or not) pausing their active participatio
 
 Each *official* subproject in Jupyter gets a single [Software Steering Council representative](https://jupyter.org/governance/software_steering_council.html#software-steering-council). Jupyter Server's representative is elected by the active team members. In the Jupyter Server subproject, our representative is elected to a one-year term.
 
-Jupyter Server's SSC representative is Zach Sailer.
+Current SSC Representative:
+
+```{eval-rst}
+
+.. include:: team/ssc-current.txt
+
+```
+
+
+Previous SSC representatives:
+
+```{eval-rst}
+
+.. include:: team/ssc-past.txt
+
+```
+

--- a/docs/team.md
+++ b/docs/team.md
@@ -42,4 +42,3 @@ Previous SSC representatives:
 .. include:: team/ssc-past.txt
 
 ```
-

--- a/docs/team/contributors-jupyter-server.yaml
+++ b/docs/team/contributors-jupyter-server.yaml
@@ -36,6 +36,8 @@
   affiliation: J.P. Morgan Chase
   team: active
   last-check-in: 2024-01
+  ssc:
+    - 2024/04-
 
 - name: Brian Granger
   handle: "@ellisonbg"
@@ -66,6 +68,8 @@
   affiliation: Apple
   team: active
   last-check-in: 2024-01
+  ssc:
+    - 2023/01-2024/04
 
 - name: Steve Silvester
   handle: "@blink1073"


### PR DESCRIPTION
Add @vidartf to the documentation page as the next representative.

Also adds a section to our team compass to list previous SSC representatives. I think this is good practice going forward, so we have a record of who+when different folks represented the team. 